### PR TITLE
Fix some handling of environment variables

### DIFF
--- a/mrblib/resource_executor/cron.rb
+++ b/mrblib/resource_executor/cron.rb
@@ -238,7 +238,7 @@ module ::MItamae
             newcron << "#{v.to_s.upcase}=\"#{desired.send(v)}\"\n" if desired.send(v)
           end
           desired.environment.each do |name, value|
-            newcron << "#{name}=#{value}\n"
+            newcron << "#{name}=#{value.shellescape}\n"
           end
           if desired.time
             newcron << "@#{desired.time} #{desired.command}\n"

--- a/mrblib/resource_executor/cron.rb
+++ b/mrblib/resource_executor/cron.rb
@@ -72,7 +72,7 @@ module ::MItamae
                 current.cron_exists = true
                 next
               when ENV_PATTERN
-                set_environment_var($1, $2) if cron_found
+                set_environment_var($1, $2, current: current) if cron_found
                 next
               when SPECIAL_PATTERN
                 if cron_found
@@ -200,7 +200,7 @@ module ::MItamae
           end
         end
 
-        def set_environment_var(attr_name, attr_value)
+        def set_environment_var(attr_name, attr_value, current: nil)
           if %w{MAILTO PATH SHELL HOME}.include?(attr_name)
             current.send("#{attr_name.downcase}=", attr_value)
           else


### PR DESCRIPTION
Hi,

This resolves issues with environment variables passed via the environment attribute: explicitly passes the `current` variable to the setter and shell-escapes environment variable values.

Thanks,